### PR TITLE
Fix for mt_heal (L4D1)

### DIFF
--- a/addons/sourcemod/scripting/include/mutant_tanks.inc
+++ b/addons/sourcemod/scripting/include/mutant_tanks.inc
@@ -901,6 +901,20 @@ stock void vSpecialAttack(int tank, float pos[3], float offset, const char[] mod
 	}
 }
 
+stock void vStopSound(client, const char[] sound)
+{
+	StopSound(client, SNDCHAN_REPLACE, sound);
+	StopSound(client, SNDCHAN_AUTO, sound);
+	StopSound(client, SNDCHAN_WEAPON, sound);
+	StopSound(client, SNDCHAN_VOICE, sound);
+	StopSound(client, SNDCHAN_ITEM, sound);
+	StopSound(client, SNDCHAN_BODY, sound);
+	StopSound(client, SNDCHAN_STREAM, sound);
+	StopSound(client, SNDCHAN_STATIC, sound);
+	StopSound(client, SNDCHAN_VOICE_BASE, sound);
+	StopSound(client, SNDCHAN_USER_BASE, sound);
+}
+
 // Chat
 stock void MT_PrintToChat(int client, char[] message, any ...)
 {

--- a/addons/sourcemod/scripting/mutant_tanks/mt_heal.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_heal.sp
@@ -744,6 +744,9 @@ static void vReset2(int tank)
 
 static void vResetGlow(int tank)
 {
+	if (!bIsValidGame())
+		return;
+
 	switch (MT_IsGlowEnabled(tank))
 	{
 		case true:

--- a/addons/sourcemod/scripting/mutant_tanks/mt_heal.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_heal.sp
@@ -411,7 +411,7 @@ public void MT_OnEventFired(Event event, const char[] name, bool dontBroadcast)
 			SetEntProp(iSurvivor, Prop_Send, "m_currentReviveCount", 0);
 			SetEntProp(iSurvivor, Prop_Send, "m_isGoingToDie", 0);
 
-			StopSound(iSurvivor, SNDCHAN_AUTO, SOUND_HEARTBEAT);
+			vStopSound(iSurvivor, SOUND_HEARTBEAT);
 		}
 	}
 	else if (StrEqual(name, "player_death"))
@@ -419,7 +419,7 @@ public void MT_OnEventFired(Event event, const char[] name, bool dontBroadcast)
 		int iUserId = event.GetInt("userid"), iPlayer = GetClientOfUserId(iUserId);
 		if (bIsSurvivor(iPlayer))
 		{
-			StopSound(iPlayer, SNDCHAN_AUTO, SOUND_HEARTBEAT);
+			vStopSound(iPlayer, SOUND_HEARTBEAT);
 		}
 		else if (MT_IsTankSupported(iPlayer, MT_CHECK_INDEX|MT_CHECK_INGAME|MT_CHECK_KICKQUEUE))
 		{

--- a/addons/sourcemod/scripting/mutant_tanks/mt_kamikaze.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_kamikaze.sp
@@ -48,9 +48,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 #define PARTICLE_BLOOD "boomer_explode_D"
 
-#define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav"
-#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav"
-#define SOUND_SMASH "player/charger/hit/charger_smash_02.wav"
+#define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav" //Only exists on L4D2
+#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav" //Only exists on L4D1
+#define SOUND_SMASH "player/charger/hit/charger_smash_02.wav" //Only exists on L4D2
 #define SOUND_SMASH_L4D1 "player/tank/hit/hulk_punch_1.wav"
 
 #define MT_MENU_KAMIKAZE "Kamikaze Ability"

--- a/addons/sourcemod/scripting/mutant_tanks/mt_kamikaze.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_kamikaze.sp
@@ -413,12 +413,12 @@ static void vKamikaze(int survivor, int tank)
 
 	if (bIsValidGame())
 	{
-		EmitSoundToAll(SOUND_SMASH, tank);
+		EmitSoundToAll(SOUND_SMASH, survivor);
 		EmitSoundToAll(SOUND_GROWL, tank);
 	}
 	else
 	{
-		EmitSoundToAll(SOUND_SMASH_L4D1, tank);
+		EmitSoundToAll(SOUND_SMASH_L4D1, survivor);
 		EmitSoundToAll(SOUND_GROWL_L4D1, tank);
 	}
 	vAttachParticle(survivor, PARTICLE_BLOOD, 0.1, 0.0);

--- a/addons/sourcemod/scripting/mutant_tanks/mt_kamikaze.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_kamikaze.sp
@@ -49,7 +49,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 #define PARTICLE_BLOOD "boomer_explode_D"
 
 #define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav"
+#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav"
 #define SOUND_SMASH "player/charger/hit/charger_smash_02.wav"
+#define SOUND_SMASH_L4D1 "player/tank/hit/hulk_punch_1.wav"
 
 #define MT_MENU_KAMIKAZE "Kamikaze Ability"
 
@@ -106,7 +108,16 @@ public void OnMapStart()
 	vPrecacheParticle(PARTICLE_BLOOD);
 
 	PrecacheSound(SOUND_GROWL, true);
-	PrecacheSound(SOUND_SMASH, true);
+	if (bIsValidGame())
+	{
+		PrecacheSound(SOUND_GROWL, true);
+		PrecacheSound(SOUND_SMASH, true);
+	}
+	else
+	{
+		PrecacheSound(SOUND_GROWL_L4D1, true);
+		PrecacheSound(SOUND_SMASH_L4D1, true);
+	}
 
 	vReset();
 }
@@ -400,8 +411,16 @@ static void vKamikaze(int survivor, int tank)
 		return;
 	}
 
-	EmitSoundToAll(SOUND_SMASH, survivor);
-	EmitSoundToAll(SOUND_GROWL, tank);
+	if (bIsValidGame())
+	{
+		EmitSoundToAll(SOUND_SMASH, tank);
+		EmitSoundToAll(SOUND_GROWL, tank);
+	}
+	else
+	{
+		EmitSoundToAll(SOUND_SMASH_L4D1, tank);
+		EmitSoundToAll(SOUND_GROWL_L4D1, tank);
+	}
 	vAttachParticle(survivor, PARTICLE_BLOOD, 0.1, 0.0);
 }
 
@@ -460,7 +479,10 @@ static void vKamikazeHit(int survivor, int tank, float chance, int enabled, int 
 				MT_PrintToChat(tank, "%s %t", MT_TAG3, "KamikazeHuman");
 			}
 
-			EmitSoundToAll(SOUND_SMASH, survivor);
+			if (bIsValidGame())
+				EmitSoundToAll(SOUND_SMASH, survivor);
+			else
+				EmitSoundToAll(SOUND_SMASH_L4D1, survivor);
 			vAttachParticle(survivor, PARTICLE_BLOOD, 0.1, 0.0);
 			ForcePlayerSuicide(survivor);
 

--- a/addons/sourcemod/scripting/mutant_tanks/mt_rocket.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_rocket.sp
@@ -49,8 +49,8 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 #define SPRITE_FIRE "sprites/sprite_fire01.vmt"
 
 #define SOUND_EXPLOSION "ambient/explosions/explode_2.wav"
-#define SOUND_FIRE "weapons/rpg/rocketfire1.wav"
-#define SOUND_LAUNCH "npc/env_headcrabcanister/launch.wav"
+#define SOUND_FIRE "weapons/molotov/fire_ignite_1.wav"
+#define SOUND_LAUNCH "player/boomer/explode/explo_medium_14.wav"
 
 #define MT_MENU_ROCKET "Rocket Ability"
 

--- a/addons/sourcemod/scripting/mutant_tanks/mt_rocket.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_rocket.sp
@@ -48,7 +48,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 #define SPRITE_FIRE "sprites/sprite_fire01.vmt"
 
-#define SOUND_EXPLOSION "ambient/explosions/exp2.wav"
+#define SOUND_EXPLOSION "ambient/explosions/explode_2.wav"
 #define SOUND_FIRE "weapons/rpg/rocketfire1.wav"
 #define SOUND_LAUNCH "npc/env_headcrabcanister/launch.wav"
 

--- a/addons/sourcemod/scripting/mutant_tanks/mt_slow.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_slow.sp
@@ -532,7 +532,7 @@ static void vSlowHit(int survivor, int tank, float chance, int enabled, int mess
 					MT_PrintToChat(tank, "%s %t", MT_TAG3, "SlowHuman", g_iSlowCount[tank], g_iHumanAmmo[MT_GetTankType(tank)]);
 				}
 
-				SetEntPropFloat(tank, Prop_Send, "m_flLaggedMovementValue", g_flSlowSpeed[MT_GetTankType(tank)]);
+				SetEntPropFloat(survivor, Prop_Send, "m_flLaggedMovementValue", g_flSlowSpeed[MT_GetTankType(tank)]);
 
 				DataPack dpStopSlow;
 				CreateDataTimer(g_flSlowDuration[MT_GetTankType(tank)], tTimerStopSlow, dpStopSlow, TIMER_FLAG_NO_MAPCHANGE);

--- a/addons/sourcemod/scripting/mutant_tanks/mt_smash.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_smash.sp
@@ -453,12 +453,12 @@ static void vSmash(int survivor, int tank)
 
 	if (bIsValidGame())
 	{
-		EmitSoundToAll(SOUND_SMASH, tank);
+		EmitSoundToAll(SOUND_SMASH, survivor);
 		EmitSoundToAll(SOUND_GROWL, tank);
 	}
 	else
 	{
-		EmitSoundToAll(SOUND_SMASH_L4D1, tank);
+		EmitSoundToAll(SOUND_SMASH_L4D1, survivor);
 		EmitSoundToAll(SOUND_GROWL_L4D1, tank);
 	}
 	vAttachParticle(survivor, PARTICLE_BLOOD, 0.1, 0.0);

--- a/addons/sourcemod/scripting/mutant_tanks/mt_smash.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_smash.sp
@@ -49,7 +49,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 #define PARTICLE_BLOOD "boomer_explode_D"
 
 #define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav"
+#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav"
 #define SOUND_SMASH "player/charger/hit/charger_smash_02.wav"
+#define SOUND_SMASH_L4D1 "player/tank/hit/hulk_punch_1.wav"
 
 #define MT_MENU_SMASH "Smash Ability"
 
@@ -105,8 +107,16 @@ public void OnMapStart()
 {
 	vPrecacheParticle(PARTICLE_BLOOD);
 
-	PrecacheSound(SOUND_GROWL, true);
-	PrecacheSound(SOUND_SMASH, true);
+	if (bIsValidGame())
+	{
+		PrecacheSound(SOUND_GROWL, true);
+		PrecacheSound(SOUND_SMASH, true);
+	}
+	else
+	{
+		PrecacheSound(SOUND_GROWL_L4D1, true);
+		PrecacheSound(SOUND_SMASH_L4D1, true);
+	}
 
 	vReset();
 }
@@ -441,8 +451,16 @@ static void vSmash(int survivor, int tank)
 		return;
 	}
 
-	EmitSoundToAll(SOUND_SMASH, survivor);
-	EmitSoundToAll(SOUND_GROWL, tank);
+	if (bIsValidGame())
+	{
+		EmitSoundToAll(SOUND_SMASH, tank);
+		EmitSoundToAll(SOUND_GROWL, tank);
+	}
+	else
+	{
+		EmitSoundToAll(SOUND_SMASH_L4D1, tank);
+		EmitSoundToAll(SOUND_GROWL_L4D1, tank);
+	}
 	vAttachParticle(survivor, PARTICLE_BLOOD, 0.1, 0.0);
 }
 

--- a/addons/sourcemod/scripting/mutant_tanks/mt_smash.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_smash.sp
@@ -48,9 +48,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 #define PARTICLE_BLOOD "boomer_explode_D"
 
-#define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav"
-#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav"
-#define SOUND_SMASH "player/charger/hit/charger_smash_02.wav"
+#define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav" //Only exists on L4D2
+#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav" //Only exists on L4D1
+#define SOUND_SMASH "player/charger/hit/charger_smash_02.wav" //Only exists on L4D2
 #define SOUND_SMASH_L4D1 "player/tank/hit/hulk_punch_1.wav"
 
 #define MT_MENU_SMASH "Smash Ability"

--- a/addons/sourcemod/scripting/mutant_tanks/mt_ultimate.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_ultimate.sp
@@ -49,7 +49,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 #define PARTICLE_ELECTRICITY "electrical_arc_01_system"
 
 #define SOUND_ELECTRICITY "items/suitchargeok1.wav"
-#define SOUND_EXPLOSION "ambient/explosions/exp2.wav"
+#define SOUND_EXPLOSION "ambient/explosions/explode_2.wav"
 #define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav"
 #define SOUND_SMASH "player/charger/hit/charger_smash_02.wav"
 

--- a/addons/sourcemod/scripting/mutant_tanks/mt_ultimate.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_ultimate.sp
@@ -51,7 +51,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 #define SOUND_ELECTRICITY "items/suitchargeok1.wav"
 #define SOUND_EXPLOSION "ambient/explosions/explode_2.wav"
 #define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav"
+#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav"
 #define SOUND_SMASH "player/charger/hit/charger_smash_02.wav"
+#define SOUND_SMASH_L4D1 "player/tank/hit/hulk_punch_1.wav"
 
 #define MT_MENU_ULTIMATE "Ultimate Ability"
 
@@ -109,8 +111,16 @@ public void OnMapStart()
 
 	PrecacheSound(SOUND_ELECTRICITY, true);
 	PrecacheSound(SOUND_EXPLOSION, true);
-	PrecacheSound(SOUND_GROWL, true);
-	PrecacheSound(SOUND_SMASH, true);
+	if (bIsValidGame())
+	{
+		PrecacheSound(SOUND_GROWL, true);
+		PrecacheSound(SOUND_SMASH, true);
+	}
+	else
+	{
+		PrecacheSound(SOUND_GROWL_L4D1, true);
+		PrecacheSound(SOUND_SMASH_L4D1, true);
+	}
 
 	vReset();
 }
@@ -473,8 +483,16 @@ static void vUltimateAbility(int tank)
 			vAttachParticle(tank, PARTICLE_ELECTRICITY, 2.0, 30.0);
 			EmitSoundToAll(SOUND_ELECTRICITY, tank);
 			EmitSoundToAll(SOUND_EXPLOSION, tank);
-			EmitSoundToAll(SOUND_GROWL, tank);
-			EmitSoundToAll(SOUND_SMASH, tank);
+			if (bIsValidGame())
+			{
+				EmitSoundToAll(SOUND_SMASH, tank);
+				EmitSoundToAll(SOUND_GROWL, tank);
+			}
+			else
+			{
+				EmitSoundToAll(SOUND_SMASH_L4D1, tank);
+				EmitSoundToAll(SOUND_GROWL_L4D1, tank);
+			}
 
 			SetEntityHealth(tank, RoundToNearest(g_iUltimateHealth[tank] * g_flUltimateHealthPortion[MT_GetTankType(tank)]));
 

--- a/addons/sourcemod/scripting/mutant_tanks/mt_ultimate.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mt_ultimate.sp
@@ -50,9 +50,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 #define SOUND_ELECTRICITY "items/suitchargeok1.wav"
 #define SOUND_EXPLOSION "ambient/explosions/explode_2.wav"
-#define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav"
-#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav"
-#define SOUND_SMASH "player/charger/hit/charger_smash_02.wav"
+#define SOUND_GROWL "player/tank/voice/growl/tank_climb_01.wav" //Only exists on L4D2
+#define SOUND_GROWL_L4D1 "player/tank/voice/growl/hulk_growl_1.wav" //Only exists on L4D1
+#define SOUND_SMASH "player/charger/hit/charger_smash_02.wav" //Only exists on L4D2
 #define SOUND_SMASH_L4D1 "player/tank/hit/hulk_punch_1.wav"
 
 #define MT_MENU_ULTIMATE "Ultimate Ability"

--- a/addons/sourcemod/scripting/mutant_tanks/mutant_tanks.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mutant_tanks.sp
@@ -3290,8 +3290,11 @@ static void vHookEvents(bool hook)
 		HookEvent("player_bot_replace", vEventHandler);
 		HookEvent("player_death", vEventHandler);
 		HookEvent("player_incapacitated", vEventHandler);
-		HookEvent("player_now_it", vEventHandler);
-		HookEvent("player_no_longer_it", vEventHandler);
+		if (bIsValidGame())
+		{
+			HookEvent("player_now_it", vEventHandler);
+			HookEvent("player_no_longer_it", vEventHandler);
+		}
 		HookEvent("player_spawn", vEventHandler);
 
 		vHookEventForward(true);
@@ -3309,8 +3312,11 @@ static void vHookEvents(bool hook)
 		UnhookEvent("player_bot_replace", vEventHandler);
 		UnhookEvent("player_death", vEventHandler);
 		UnhookEvent("player_incapacitated", vEventHandler);
-		UnhookEvent("player_now_it", vEventHandler);
-		UnhookEvent("player_no_longer_it", vEventHandler);
+		if (bIsValidGame())
+		{		
+			UnhookEvent("player_now_it", vEventHandler);
+			UnhookEvent("player_no_longer_it", vEventHandler);
+		}
 		UnhookEvent("player_spawn", vEventHandler);
 
 		vHookEventForward(false);

--- a/addons/sourcemod/scripting/mutant_tanks/mutant_tanks.sp
+++ b/addons/sourcemod/scripting/mutant_tanks/mutant_tanks.sp
@@ -3106,7 +3106,6 @@ public void vEventHandler(Event event, const char[] name, bool dontBroadcast)
  			if (bIsTank(iTank, MT_CHECK_INDEX|MT_CHECK_INGAME|MT_CHECK_KICKQUEUE))
 			{
 				SetEntProp(iTank, Prop_Send, "m_iGlowType", 0);
-				SetEntProp(iTank, Prop_Send, "m_glowColorOverride", 0);
 			}
 		}
 		else if (StrEqual(name, "player_no_longer_it"))
@@ -3121,7 +3120,6 @@ public void vEventHandler(Event event, const char[] name, bool dontBroadcast)
 				}
 
 				SetEntProp(iTank, Prop_Send, "m_iGlowType", 3);
-				SetEntProp(iTank, Prop_Send, "m_glowColorOverride", iGetRGBColor(iGlowColor[0], iGlowColor[1], iGlowColor[2]));
 			}
 		}
 		else if (StrEqual(name, "player_spawn"))


### PR DESCRIPTION
Added a check if is a valid game (L4D2)
Setting glow on L4D1 game was generating an exception.

L 05/02/2019 - 11:33:57: [SM] Exception reported: Property "m_iGlowType" not found (entity 1/tank)
L 05/02/2019 - 11:33:57: [SM] Blaming: mutant_tanks\mt_heal.smx
L 05/02/2019 - 11:33:57: [SM] Call stack trace:
L 05/02/2019 - 11:33:57: [SM]   [0] SetEntProp
L 05/02/2019 - 11:33:57: [SM]   [1] Line 762, mt_heal.sp::vResetGlow
L 05/02/2019 - 11:33:57: [SM]   [2] Line 900, mt_heal.sp::tTimerHeal